### PR TITLE
Add method to FSSound to download previews

### DIFF
--- a/Source/FreesoundAPI.cpp
+++ b/Source/FreesoundAPI.cpp
@@ -344,9 +344,13 @@ SoundList FreesoundClient::getSimilarSounds(String id, String descriptorsFilter,
 URL::DownloadTask* FreesoundClient::downloadSound(FSSound sound, const File & location, URL::DownloadTask::Listener * listener)
 {
 	URL address = sound.getDownload();
-	
-
 	return address.downloadToFile(location, "Authorization: " + header, listener);
+}
+
+URL::DownloadTask* FreesoundClient::downloadOGGSoundPreview(FSSound sound, const File & location, URL::DownloadTask::Listener * listener)
+{
+    URL address = sound.getOGGPreviewURL();
+    return address.downloadToFile(location, "", listener);
 }
 
 int FreesoundClient::uploadSound(const File & fileToUpload, String tags, String description, String name, String license, String pack, String geotag, Callback cb)
@@ -842,7 +846,8 @@ FSSound::FSSound(var sound)
 	pack = URL(sound["pack"]);
 	download = URL(sound["download"]);
 	bookmark = URL(sound["bookmark"]);
-	images = sound["previews"];
+	previews = sound["previews"];
+    images = sound["images"];
 	numDownloads = sound["images"];
 	avgRating = sound["num_downloads"];
 	numRatings = sound["avg_rating"];
@@ -862,6 +867,26 @@ URL FSSound::getDownload()
 {
 	return download;
 }
+
+URL FSSound::getOGGPreviewURL()
+{
+    if (!previews.hasProperty("preview-hq-ogg")){
+        /*
+         If you reached this bit of code is because you're trying to download the preview of a sound
+         but the freesound-juce client does not know the URL where to find that preview.
+         
+         It can happen that the FSSound object does not have "previews" property if the object was
+         constructed from the results of a SoundList (e.g. using SoundList::toSoundArray method) and
+         the "previews" field was not initially requested in the query that created the SoundList
+         object. If you just reached this bit of code, make sure that you include the "previews" field
+         in the "fields" parameter of the function that generated the SoundList.
+         */
+        throw;
+    }
+    return URL(previews["preview-hq-ogg"]);
+}
+
+
 
 FSUser::FSUser()
 {

--- a/Source/FreesoundAPI.h
+++ b/Source/FreesoundAPI.h
@@ -278,9 +278,9 @@ public:
 	URL profile;
 	/** \brief	The username */
 	String username;
-	/** \brief	The ëaboutí text of usersí profile (if indicated)*/
+	/** \brief	The ‚Äòabout‚Äô text of users‚Äô profile (if indicated)*/
 	String about;
-	/** \brief	The URI of usersí homepage outside Freesound (if indicated)*/
+	/** \brief	The URI of users‚Äô homepage outside Freesound (if indicated)*/
 	URL homepage;
 	/** \brief	Dictionary including the URIs for the avatar of the user. 
 				The avatar is presented in three sizes Small, Medium and Large, which 
@@ -299,7 +299,7 @@ public:
 	URL packs;
 	/** \brief	The number of forum posts by the user */
 	int numPosts;
-	/** \brief	The number of comments that user made in other usersí sounds*/
+	/** \brief	The number of comments that user made in other users‚Äô sounds*/
 	int numComments;   
 	/** \brief	The URI for a list of bookmark categories by the user*/
 	URL bookmarks;
@@ -409,7 +409,7 @@ public:
 
 class FSSound {
 public:
-	/** \brief	The soundís unique identifier */
+	/** \brief	The sound‚Äôs unique identifier */
 	String id;
 	/** \brief	The URI for this sound on the Freesound website*/
 	URL url;
@@ -441,7 +441,7 @@ public:
 	int samplerate;
 	/** \brief	The username of the uploader of the sound */
 	String user;
-	/** \brief	If the sound is part of a pack, this URI points to that packís API resource */
+	/** \brief	If the sound is part of a pack, this URI points to that pack‚Äôs API resource */
 	URL pack;
 	/** \brief	The URI for retrieving the original sound */
 	URL download;
@@ -513,6 +513,19 @@ public:
 	 */
 
 	URL getDownload();
+    
+    /**
+     * \fn    URL FSSound::getOGGPreviewURL();
+     *
+     * \brief    Gets the sound the URL of the OGG preview of a sound
+     *
+     * \author    Frederic
+     * \date    12/09/2019
+     *
+     * \returns    The OGG preview URL.
+     */
+    
+    URL getOGGPreviewURL();
 };
 
 /**
@@ -781,7 +794,7 @@ public:
 	 * \author	Antonio
 	 * \date	09/07/2019
 	 *
-	 * \param	id		The soundís unique identifier.
+	 * \param	id		The sound‚Äôs unique identifier.
 	 * \param	fields	(Optional) Indicates which sound properties should be included in every sound of the response.
 	 *
 	 * \returns	A FSSound instance.
@@ -797,7 +810,7 @@ public:
 	 * \author	Antonio
 	 * \date	09/07/2019
 	 *
-	 * \param	id		   	The soundís unique identifier.
+	 * \param	id		   	The sound‚Äôs unique identifier.
 	 * \param	descriptors	(Optional) Indicates which sound content-based descriptors should be included in every sound of the response.
 	 * \param	normalized 	(Optional) Indicates whether the returned sound content-based descriptors should be normalized or not.
 	 *
@@ -843,6 +856,23 @@ public:
 	 */
 
 	URL::DownloadTask* downloadSound(FSSound sound, const File &location, URL::DownloadTask::Listener * listener = nullptr);
+    
+    /**
+     * \fn    URL::DownloadTask* FreesoundClient::downloadOGGSoundPreview(FSSound sound, const File &location, URL::DownloadTask::Listener * listener = nullptr);
+     *
+     * \brief    This resource allows you to download the preview of a sound in OGG format. The advantage of downloading a preview instead of the original file is that the file size is lower and the format is unified.
+     *
+     * \author    Frederic
+     * \date    12/09/2019
+     *
+     * \param               sound       The sound whose preview should be downloaded.
+     * \param               location    The location for the sound to be download.
+     * \param [in,out]    listener    (Optional) If non-null, the listener for the download progress.
+     *
+     * \returns    Null if it fails, else a pointer to an URL::DownloadTask.
+     */
+    
+    URL::DownloadTask* downloadOGGSoundPreview(FSSound sound, const File &location, URL::DownloadTask::Listener * listener = nullptr);
 
 	/**
 	 * \fn	int FreesoundClient::uploadSound(const File &fileToUpload, String tags, String description, String name = String(), String license = "Creative Commons 0", String pack = String(), String geotag = String(), Callback cb = [] {});
@@ -853,10 +883,10 @@ public:
 	 * \date	09/07/2019
 	 *
 	 * \param	fileToUpload	The file to upload.
-	 * \param	tags			The tags that will be assigned to the sound. Separate tags with spaces and join multi-words with dashes (e.g. ìtag1 tag2 tag3 cool-tag4î).
+	 * \param	tags			The tags that will be assigned to the sound. Separate tags with spaces and join multi-words with dashes (e.g. ‚Äútag1 tag2 tag3 cool-tag4‚Äù).
 	 * \param	description 	A textual description of the sound.
 	 * \param	name			(Optional) The name that will be given to the sound. If not provided, filename will be used.
-	 * \param	license			(Optional) The license of the sound. Must be either ìAttributionî, ìAttribution Noncommercialî or ìCreative Commons 0î.
+	 * \param	license			(Optional) The license of the sound. Must be either ‚ÄúAttribution‚Äù, ‚ÄúAttribution Noncommercial‚Äù or ‚ÄúCreative Commons 0‚Äù.
 	 * \param	pack			(Optional) The name of the pack where the sound should be included. 
 	 * \param	geotag			(Optional) Geotag information for the sound.
 	 * \param	cb				(Optional) The callback function called in the end of the function.
@@ -876,9 +906,9 @@ public:
 	 *
 	 * \param	uploadFilename	The filename of the sound to describe.
 	 * \param	description   	A textual description of the sound.
-	 * \param	license		  	The license of the sound. Must be either ìAttributionî, ìAttribution Noncommercialî or ìCreative Commons 0î.
+	 * \param	license		  	The license of the sound. Must be either ‚ÄúAttribution‚Äù, ‚ÄúAttribution Noncommercial‚Äù or ‚ÄúCreative Commons 0‚Äù.
 	 * \param	name		  	(Optional) The name that will be given to the sound. If not provided, filename will be used.
-	 * \param	tags		  	(Optional) The tags that will be assigned to the sound. Separate tags with spaces and join multi-words with dashes (e.g. ìtag1 tag2 tag3 cool-tag4î).
+	 * \param	tags		  	(Optional) The tags that will be assigned to the sound. Separate tags with spaces and join multi-words with dashes (e.g. ‚Äútag1 tag2 tag3 cool-tag4‚Äù).
 	 * \param	pack		  	(Optional) The name of the pack where the sound should be included.
 	 * \param	geotag		  	(Optional) Geotag information for the sound.
 	 *
@@ -912,7 +942,7 @@ public:
 	 * \param	name	   	(Optional) The new name that will be given to the sound.
 	 * \param	tags	   	(Optional) The new tags that will be assigned to the sound.
 	 * \param	description	(Optional) The new textual description for the sound.
-	 * \param	license	   	(Optional) The new license of the sound. Must be either ìAttributionî, ìAttribution Noncommercialî or ìCreative Commons 0î.
+	 * \param	license	   	(Optional) The new license of the sound. Must be either ‚ÄúAttribution‚Äù, ‚ÄúAttribution Noncommercial‚Äù or ‚ÄúCreative Commons 0‚Äù.
 	 * \param	pack	   	(Optional) The new name of the pack where the sound should be included. 
 	 * \param	geotag	   	(Optional) The new geotag information for the sound.
 	 * \param	cb		   	(Optional) The callback function called in the end of the function.


### PR DESCRIPTION
Added a method to `FSSound` to download OGG previews.
The method will throw an exception if the preview URL is not stored in the sound object.
Also fixed a bug in `FSSound` that wrongly assigned `images` property.

(I don't know why the diff shows some docstring lines as being changed but I did not change them on purpose. probably something that xcode did...)